### PR TITLE
Add missing dependencies to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "gulp-footer": "^1.0.4",
     "gulp-header": "^1.0.2",
     "gulp-concat": "^2.3.3",
+    "gulp-connect": "2.0.6",
+    "gulp-rename": "^1.2.0",
     "sort-stream": "^1.0.0"
   }
 }


### PR DESCRIPTION
These dependencies are missing for running `gulp server`.

Signed-off-by: Matěj Cepl mcepl@redhat.com
