### PR TITLE
Fixing html import instruction

### DIFF
--- a/docs/brick-action.html
+++ b/docs/brick-action.html
@@ -68,7 +68,7 @@ It listens to an event on a source elemenet and then calls a method on a target 
 <pre><code class="lang-html"> &lt;script src=&quot;bower_components/platform/platform.js&quot;&gt;&lt;/script&gt;</code></pre>
 </li>
 <li><p>Import Custom Element:</p>
-<pre><code class="lang-html"> &lt;link rel=&quot;import&quot; href=&quot;src/element.html&quot;&gt;</code></pre>
+<pre><code class="lang-html"> &lt;link rel=&quot;import&quot; href=&quot;src/brick-action.html&quot;&gt;</code></pre>
 </li>
 <li><p>Start using it:</p>
 <pre><code class="lang-html"> &lt;brick-action&gt;&lt;/brick-action&gt;</code></pre>

--- a/docs/brick-action.md
+++ b/docs/brick-action.md
@@ -18,7 +18,7 @@ It listens to an event on a source elemenet and then calls a method on a target 
 2. Import Custom Element:
 
     ```html
-    <link rel="import" href="src/element.html">
+    <link rel="import" href="src/brick-action.html">
     ```
 
 3. Start using it:

--- a/docs/brick-deck.html
+++ b/docs/brick-deck.html
@@ -65,7 +65,7 @@
 <pre><code class="lang-html"> &lt;script src=&quot;bower_components/platform/platform.js&quot;&gt;&lt;/script&gt;</code></pre>
 </li>
 <li><p>Import Custom Element:</p>
-<pre><code class="lang-html"> &lt;link rel=&quot;import&quot; href=&quot;src/element.html&quot;&gt;</code></pre>
+<pre><code class="lang-html"> &lt;link rel=&quot;import&quot; href=&quot;src/brick-deck.html&quot;&gt;</code></pre>
 </li>
 <li><p>Start using it:</p>
 <pre><code class="lang-html"> &lt;brick-deck selected-index=&quot;0&quot;&gt;

--- a/docs/brick-deck.md
+++ b/docs/brick-deck.md
@@ -17,7 +17,7 @@ A [Brick](https://github.com/mozbrick/brick/) box element in which cards can be 
 2. Import Custom Element:
 
     ```html
-    <link rel="import" href="src/element.html">
+    <link rel="import" href="src/brick-deck.html">
     ```
 
 3. Start using it:

--- a/docs/brick-flipbox.html
+++ b/docs/brick-flipbox.html
@@ -68,7 +68,7 @@ Flips between two content elements with a CSS Animation, similar to flipping a p
 <pre><code class="lang-html"> &lt;script src=&quot;bower_components/platform/platform.js&quot;&gt;&lt;/script&gt;</code></pre>
 </li>
 <li><p>Import Custom Element:</p>
-<pre><code class="lang-html"> &lt;link rel=&quot;import&quot; href=&quot;src/element.html&quot;&gt;</code></pre>
+<pre><code class="lang-html"> &lt;link rel=&quot;import&quot; href=&quot;src/brick-flipbox.html&quot;&gt;</code></pre>
 </li>
 <li><p>Start using it:</p>
 <pre><code class="lang-html"> &lt;brick-flipbox&gt;

--- a/docs/brick-flipbox.md
+++ b/docs/brick-flipbox.md
@@ -18,7 +18,7 @@
 2. Import Custom Element:
 
     ```html
-    <link rel="import" href="src/element.html">
+    <link rel="import" href="src/brick-flipbox.html">
     ```
 
 3. Start using it:

--- a/docs/brick-layout.html
+++ b/docs/brick-layout.html
@@ -67,7 +67,7 @@
 <pre><code class="lang-html"> &lt;script src=&quot;bower_components/platform/platform.js&quot;&gt;&lt;/script&gt;</code></pre>
 </li>
 <li><p>Import Custom Element:</p>
-<pre><code class="lang-html"> &lt;link rel=&quot;import&quot; href=&quot;src/element.html&quot;&gt;</code></pre>
+<pre><code class="lang-html"> &lt;link rel=&quot;import&quot; href=&quot;src/brick-layout.html&quot;&gt;</code></pre>
 </li>
 <li><p>Start using it:</p>
 <pre><code class="lang-html"> &lt;brick-layout&gt;&lt;/brick-layout&gt;</code></pre>

--- a/docs/brick-layout.md
+++ b/docs/brick-layout.md
@@ -17,7 +17,7 @@
 2. Import Custom Element:
 
     ```html
-    <link rel="import" href="src/element.html">
+    <link rel="import" href="src/brick-layout.html">
     ```
 
 3. Start using it:

--- a/docs/brick-tabbar.html
+++ b/docs/brick-tabbar.html
@@ -67,7 +67,7 @@
 <pre><code class="lang-html"> &lt;script src=&quot;bower_components/platform/platform.js&quot;&gt;&lt;/script&gt;</code></pre>
 </li>
 <li><p>Import Custom Element:</p>
-<pre><code class="lang-html"> &lt;link rel=&quot;import&quot; href=&quot;src/element.html&quot;&gt;</code></pre>
+<pre><code class="lang-html"> &lt;link rel=&quot;import&quot; href=&quot;src/brick-tabbar.html&quot;&gt;</code></pre>
 </li>
 <li><p>Start using it:</p>
 <pre><code class="lang-html"> &lt;brick-tabbar&gt;&lt;/brick-tabbar&gt;</code></pre>

--- a/docs/brick-tabbar.md
+++ b/docs/brick-tabbar.md
@@ -17,7 +17,7 @@
 2. Import Custom Element:
 
     ```html
-    <link rel="import" href="src/element.html">
+    <link rel="import" href="src/brick-tabbar.html">
     ```
 
 3. Start using it:


### PR DESCRIPTION
The various instruction using html import were referring to an not existent element.html page,
amended the various paths matching the correct html files as in their project structure.

@potch, the path are now assuming one requires each custom-element as stand-alone, 
not sure this instruction are useful when requiring bower_components/brick/dist/brick.html as it will be imported from there.
